### PR TITLE
Fix missing handles for ReactFlow custom nodes

### DIFF
--- a/src/components/PlaylistNode.tsx
+++ b/src/components/PlaylistNode.tsx
@@ -1,5 +1,5 @@
 // src/components/PlaylistNode.tsx
-import { NodeProps } from "reactflow";
+import { NodeProps, Handle, Position } from "reactflow";
 
 export default function PlaylistNode({ data }: NodeProps) {
   return (
@@ -12,6 +12,8 @@ export default function PlaylistNode({ data }: NodeProps) {
         </div>
       )}
       <div className="mt-2 text-sm font-medium text-gray-800">{data.label}</div>
+      {/* Source handle for edges from this playlist */}
+      <Handle type="source" position={Position.Bottom} id="playlist-source" />
     </div>
   );
 }

--- a/src/components/SongNode.tsx
+++ b/src/components/SongNode.tsx
@@ -1,10 +1,12 @@
 // src/components/SongNode.tsx
-import { NodeProps } from "reactflow";
+import { NodeProps, Handle, Position } from "reactflow";
 
 export default function SongNode({ data }: NodeProps) {
   return (
-    <div className="flex items-center bg-white border border-gray-300 rounded-md shadow p-1"
-         style={{ minWidth: 100 }}>
+    <div
+      className="flex items-center bg-white border border-gray-300 rounded-md shadow p-1"
+      style={{ minWidth: 100 }}
+    >
       {data.image ? (
         <img src={data.image} alt="Album art" className="h-10 w-10 object-cover rounded-sm" />
       ) : (
@@ -13,6 +15,8 @@ export default function SongNode({ data }: NodeProps) {
         </div>
       )}
       <div className="ml-2 text-xs font-normal text-gray-800">{data.label}</div>
+      {/* Target handle for edges coming into this song */}
+      <Handle type="target" position={Position.Top} id="song-target" />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add React Flow `Handle` components to `PlaylistNode`
- add a target handle to `SongNode` so edges have endpoints

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68433c9e0f5483329f52ee6be664489f