### PR TITLE
Fix React Flow handle IDs

### DIFF
--- a/src/components/graph-canvas.tsx
+++ b/src/components/graph-canvas.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useMemo } from "react";
 import ReactFlow, { Background, Edge, Node, NodeTypes } from "reactflow";
 import "reactflow/dist/style.css";
 import PlaylistNode from "@/components/PlaylistNode";
@@ -17,10 +17,13 @@ export default function GraphCanvas() {
   const [isLoading, setIsLoading] = useState(true);
 
   // Define which React component to render for each node type
-  const nodeTypes: NodeTypes = {
-    playlist: PlaylistNode,
-    song: SongNode,
-  };
+  const nodeTypes = useMemo<NodeTypes>(
+    () => ({
+      playlist: PlaylistNode,
+      song: SongNode,
+    }),
+    []
+  );
 
   useEffect(() => {
     (async () => {
@@ -62,6 +65,8 @@ export default function GraphCanvas() {
           id: e.id,
           source: e.source,
           target: e.target,
+          sourceHandle: e.sourceHandle,
+          targetHandle: e.targetHandle,
         }));
 
         setNodes(rfNodes);

--- a/src/lib/graph.ts
+++ b/src/lib/graph.ts
@@ -20,6 +20,8 @@ export type Edge = {
   id: string;
   source: string;
   target: string;
+  sourceHandle: string;
+  targetHandle: string;
 };
 
 // Layout constants for a simple grid to avoid overlapping nodes
@@ -145,6 +147,8 @@ export async function buildGraph(
         id: `${plId}-${trackId}`,
         source: plId,
         target: trackId,
+        sourceHandle: "playlist-source",
+        targetHandle: "song-target",
       });
     });
 


### PR DESCRIPTION
## Summary
- memoize nodeTypes in GraphCanvas
- include handle IDs when mapping edges
- extend edge type with handle IDs and generate them in buildGraph

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6843409db1fc83328b8b0bcae9e360e7