### PR TITLE
Enhance graph behavior and square covers

### DIFF
--- a/src/components/PlaylistNode.tsx
+++ b/src/components/PlaylistNode.tsx
@@ -1,13 +1,20 @@
 // src/components/PlaylistNode.tsx
 import { NodeProps, Handle, Position } from "reactflow";
 
-export default function PlaylistNode({ data }: NodeProps) {
+export default function PlaylistNode({ data, style }: NodeProps) {
   return (
-    <div className="flex flex-col items-center bg-white border border-gray-300 rounded-md shadow-md p-2 w-44">
+    <div
+      className="flex flex-col items-center bg-white border border-gray-300 rounded-md shadow-md p-2"
+      style={style}
+    >
       {data.image ? (
-        <img src={data.image} alt="Playlist cover" className="h-24 w-full object-cover rounded-md" />
+        <img
+          src={data.image}
+          alt="Playlist cover"
+          className="w-full aspect-square object-cover rounded-md"
+        />
       ) : (
-        <div className="h-24 w-full bg-gray-100 rounded-md flex items-center justify-center text-gray-400">
+        <div className="w-full aspect-square bg-gray-100 rounded-md flex items-center justify-center text-gray-400">
           No Image
         </div>
       )}

--- a/src/components/SongNode.tsx
+++ b/src/components/SongNode.tsx
@@ -1,11 +1,11 @@
 // src/components/SongNode.tsx
 import { NodeProps, Handle, Position } from "reactflow";
 
-export default function SongNode({ data }: NodeProps) {
+export default function SongNode({ data, style }: NodeProps) {
   return (
     <div
       className="flex items-center bg-white border border-gray-300 rounded-md shadow p-1"
-      style={{ minWidth: 100 }}
+      style={{ minWidth: 100, ...style }}
     >
       {data.image ? (
         <img src={data.image} alt="Album art" className="h-10 w-10 object-cover rounded-sm" />

--- a/src/components/graph-canvas.tsx
+++ b/src/components/graph-canvas.tsx
@@ -1,7 +1,20 @@
 "use client";
 
-import React, { useEffect, useState, useMemo } from "react";
-import ReactFlow, { Background, Edge, Node, NodeTypes } from "reactflow";
+import React, {
+  useEffect,
+  useState,
+  useMemo,
+  useCallback,
+} from "react";
+import ReactFlow, {
+  Background,
+  Edge,
+  Node,
+  NodeTypes,
+  NodeMouseHandler,
+  NodeDragHandler,
+  ReactFlowInstance,
+} from "reactflow";
 import "reactflow/dist/style.css";
 import PlaylistNode from "@/components/PlaylistNode";
 import SongNode from "@/components/SongNode";
@@ -15,6 +28,8 @@ export default function GraphCanvas() {
   const [nodes, setNodes] = useState<Node[]>([]);
   const [edges, setEdges] = useState<Edge[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [hoverId, setHoverId] = useState<string | null>(null);
+  const [rfInstance, setRfInstance] = useState<ReactFlowInstance | null>(null);
 
   // Define which React component to render for each node type
   const nodeTypes = useMemo<NodeTypes>(
@@ -69,6 +84,27 @@ export default function GraphCanvas() {
           targetHandle: e.targetHandle,
         }));
 
+        // Degree map for sizing and layout
+        const degree = new Map<string, number>();
+        rfEdges.forEach((e) => {
+          degree.set(e.source, (degree.get(e.source) ?? 0) + 1);
+          degree.set(e.target, (degree.get(e.target) ?? 0) + 1);
+        });
+
+        // Radial layout: sort by degree so hubs are near center
+        const sorted = [...rfNodes].sort(
+          (a, b) => (degree.get(b.id) ?? 0) - (degree.get(a.id) ?? 0)
+        );
+        const radiusStep = 120;
+        sorted.forEach((node, idx) => {
+          const deg = degree.get(node.id) ?? 1;
+          const radius = radiusStep * Math.log2(deg + 1);
+          const angle = (idx / sorted.length) * Math.PI * 2;
+          node.position = { x: Math.cos(angle) * radius, y: Math.sin(angle) * radius };
+          const size = 60 + deg * 10;
+          node.style = { ...node.style, width: size, height: size };
+        });
+
         setNodes(rfNodes);
         setEdges(rfEdges);
         setIsLoading(false);
@@ -78,7 +114,7 @@ export default function GraphCanvas() {
       }
     })();
   }, []);
-  
+
 
   if (isLoading) {
     return (
@@ -89,14 +125,93 @@ export default function GraphCanvas() {
     );
   }
 
+  // Highlight logic for hover spotlight
+  const displayNodes = useMemo(() => {
+    if (!hoverId) return nodes;
+    const connected = new Set<string>();
+    edges.forEach((e) => {
+      if (e.source === hoverId) connected.add(e.target);
+      if (e.target === hoverId) connected.add(e.source);
+    });
+    return nodes.map((n) => ({
+      ...n,
+      style: {
+        ...n.style,
+        opacity: n.id === hoverId || connected.has(n.id) ? 1 : 0.1,
+      },
+    }));
+  }, [nodes, edges, hoverId]);
+
+  const displayEdges = useMemo(() => {
+    if (!hoverId) return edges;
+    return edges.map((e) => ({
+      ...e,
+      style: {
+        ...(e.style ?? {}),
+        opacity: e.source === hoverId || e.target === hoverId ? 1 : 0.1,
+      },
+    }));
+  }, [edges, hoverId]);
+
+  const onNodeEnter: NodeMouseHandler = (_, n) => setHoverId(n.id);
+  const onNodeLeave: NodeMouseHandler = () => setHoverId(null);
+
+  const resolveCollision = (moving: Node, others: Node[]) => {
+    const r1 = (moving.style?.width ?? 40) / 2 + 10;
+    others.forEach((o) => {
+      if (o.id === moving.id) return;
+      const r2 = (o.style?.width ?? 40) / 2 + 10;
+      const dx = moving.position.x - o.position.x;
+      const dy = moving.position.y - o.position.y;
+      const dist = Math.sqrt(dx * dx + dy * dy);
+      const minDist = r1 + r2;
+      if (dist < minDist && dist > 0) {
+        const angle = Math.atan2(dy, dx);
+        const shift = (minDist - dist) / 2;
+        o.position = {
+          x: o.position.x - Math.cos(angle) * shift,
+          y: o.position.y - Math.sin(angle) * shift,
+        };
+      }
+    });
+  };
+
+  const onDrag: NodeDragHandler = (_, node) => {
+    setNodes((nds) => {
+      const updated = nds.map((n) => (n.id === node.id ? { ...n, position: node.position } : { ...n }));
+      const moving = updated.find((n) => n.id === node.id)!;
+      resolveCollision(moving, updated);
+      return updated;
+    });
+  };
+
+  const onInit = useCallback((inst: ReactFlowInstance) => {
+    setRfInstance(inst);
+    inst.fitView();
+  }, []);
+
+  useEffect(() => {
+    rfInstance?.fitView();
+  }, [rfInstance, nodes]);
+
   return (
     <div className="h-screen w-full">
       <ReactFlow
-        nodes={nodes}
-        edges={edges}
+        nodes={displayNodes}
+        edges={displayEdges}
         nodeTypes={nodeTypes}
+        onNodeMouseEnter={onNodeEnter}
+        onNodeMouseLeave={onNodeLeave}
+        onNodeDrag={onDrag}
+        onInit={onInit}
         fitView
-        defaultEdgeOptions={{ animated: false }}
+        proOptions={{ hideAttribution: true }}
+        defaultEdgeOptions={{
+          animated: false,
+          style: { stroke: "rgba(220,220,220,0.6)", strokeWidth: 1 },
+        }}
+        panOnDrag
+        zoomOnScroll
       >
         <Background variant="dots" gap={16} size={1} />
       </ReactFlow>


### PR DESCRIPTION
## Summary
- make playlist covers square and allow nodes to use inline sizing
- let song nodes respect style from React Flow
- add hover spotlight, basic collision avoidance and radial layout
- use fitView on init and subtle edges

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843428507848332a8f19ef337c6cf6a