### PR TITLE
Add OpenAI joke button

### DIFF
--- a/src/app/api/joke/route.ts
+++ b/src/app/api/joke/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+  try {
+    const res = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: "gpt-3.5-turbo",
+        messages: [{ role: "user", content: "Tell me a short joke." }],
+      }),
+    });
+
+    const json = await res.json();
+    const text = json.choices?.[0]?.message?.content ?? "";
+    return NextResponse.json({ text });
+  } catch (err: any) {
+    console.error("OpenAI joke error:", err);
+    return NextResponse.json({ error: "Failed to fetch joke" }, { status: 500 });
+  }
+}

--- a/src/components/graph-canvas.tsx
+++ b/src/components/graph-canvas.tsx
@@ -36,9 +36,20 @@ export default function GraphCanvas() {
   const [isLoading, setIsLoading] = useState(true);
   const [hoverId, setHoverId] = useState<string | null>(null);
   const [rfInstance, setRfInstance] = useState<ReactFlowInstance | null>(null);
+  const [aiMessage, setAiMessage] = useState<string>("");
 
   // Define which React component to render for each node type
   const nodeTypes = NODE_TYPES;
+
+  const fetchJoke = async () => {
+    try {
+      const res = await fetch("/api/joke");
+      const data = await res.json();
+      if (data.text) setAiMessage(data.text);
+    } catch (err) {
+      console.error("/api/joke error", err);
+    }
+  };
 
   useEffect(() => {
     (async () => {
@@ -187,7 +198,20 @@ export default function GraphCanvas() {
   }, [rfInstance, nodes]);
 
   return (
-    <div className="h-screen w-full">
+    <div className="relative h-screen w-full">
+      <div className="absolute top-4 right-4 z-10 flex flex-col items-end space-y-2">
+        <button
+          onClick={fetchJoke}
+          className="bg-blue-500 text-white text-sm px-3 py-1 rounded"
+        >
+          Get Joke
+        </button>
+        {aiMessage && (
+          <div className="bg-white dark:bg-gray-800 text-sm p-2 rounded shadow max-w-xs">
+            {aiMessage}
+          </div>
+        )}
+      </div>
       {isLoading ? (
         <div className="flex items-center justify-center h-full">
           <div className="animate-spin rounded-full h-12 w-12 border-t-4 border-blue-500" />


### PR DESCRIPTION
## Summary
- add an API route `/api/joke` that calls OpenAI to get a short joke
- extend `GraphCanvas` with a right-side button that fetches the joke and shows the response

## Testing
- `./node_modules/.bin/next lint` *(fails: no node_modules)*

------
https://chatgpt.com/codex/tasks/task_e_685b183a305c83329a64059b92edb68d