### PR TITLE
Add AI roast/validation from recent Spotify tracks

### DIFF
--- a/src/app/api/listening-feedback/route.ts
+++ b/src/app/api/listening-feedback/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+import { fetchRecentTracks } from "@/lib/spotify";
+
+export async function GET(req: NextRequest) {
+  try {
+    const recent = await fetchRecentTracks(req, 20);
+    const trackLines = recent.map((item, i) => {
+      const t = item.track;
+      if (!t || typeof t === "string" || !t.id) return `${i + 1}. Unknown`;
+      const artists = t.artists.map((a) => a.name).join(", ");
+      return `${i + 1}. ${t.name} — ${artists}`;
+    });
+
+    const prompt = `You are a playful music critic. Here are some songs a Spotify user recently listened to:\n${trackLines.join("\n")}\n\nRoast the user's taste based on this list, then give a genuine validation or compliment. Respond in two short paragraphs.`;
+
+    const res = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: "gpt-3.5-turbo",
+        messages: [{ role: "user", content: prompt }],
+      }),
+    });
+
+    const json = await res.json();
+    const text = json.choices?.[0]?.message?.content ?? "";
+    return NextResponse.json({ text });
+  } catch (err: any) {
+    console.error("OpenAI listening feedback error:", err);
+    return NextResponse.json(
+      { error: "Failed to fetch AI feedback" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/graph-canvas.tsx
+++ b/src/components/graph-canvas.tsx
@@ -41,17 +41,13 @@ export default function GraphCanvas() {
   // Define which React component to render for each node type
   const nodeTypes = NODE_TYPES;
 
-  const askGraphFact = async () => {
+  const askListeningFeedback = async () => {
     try {
-      const res = await fetch("/api/graph-fact", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ nodes, edges }),
-      });
+      const res = await fetch("/api/listening-feedback");
       const data = await res.json();
       if (data.text) setAiMessage(data.text);
     } catch (err) {
-      console.error("/api/graph-fact error", err);
+      console.error("/api/listening-feedback error", err);
     }
   };
 
@@ -205,7 +201,7 @@ export default function GraphCanvas() {
     <div className="relative h-screen w-full">
       <div className="absolute top-4 right-4 z-10 flex flex-col items-end space-y-2">
         <button
-          onClick={askGraphFact}
+          onClick={askListeningFeedback}
           className="bg-blue-500 text-white text-sm px-3 py-1 rounded"
         >
           Ask AI

--- a/src/lib/spotify.ts
+++ b/src/lib/spotify.ts
@@ -47,3 +47,24 @@ export async function fetchAllPlaylists(
 
   return playlists;
 }
+
+/**
+ * Fetch the user's recently played tracks from Spotify.
+ */
+export async function fetchRecentTracks(
+  req: NextRequest,
+  limit = 20
+): Promise<SpotifyApi.PlayHistoryObject[]> {
+  const accessToken = await getSpotifyToken(req);
+  const url = `${SPOTIFY_API}/me/player/recently-played?limit=${limit}`;
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  if (!res.ok) {
+    throw new Error(
+      `Spotify recent tracks fetch failed: ${res.status} ${res.statusText}`
+    );
+  }
+  const data = (await res.json()) as SpotifyApi.UsersRecentlyPlayedTracksResponse;
+  return data.items;
+}


### PR DESCRIPTION
## Summary
- fetch recent Spotify tracks via new `fetchRecentTracks` helper
- create `/api/listening-feedback` endpoint that asks OpenAI for a roast and validation
- update graph canvas button to call the new endpoint

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68630916d4bc8332a6205e8b602ba31d